### PR TITLE
case-insensitive wwn check

### DIFF
--- a/PowerShell/make-zoning.ps1
+++ b/PowerShell/make-zoning.ps1
@@ -30,7 +30,7 @@ foreach ($thisHBA in $allHBAs)
 	$thisWWN = $thisHBA.WWN
 	
 	#Use this command to verify that the WWN is advertised on that switch
-	$allCommands += "nsshow | grep $thisWWN"
+	$allCommands += "nsshow | grep -i $thisWWN"
 	#Create the Alias
 	$thisAlias = "$thisVMHost`_$thisDevice"
 	$allCommands += "aliCreate ""$thisAlias"", ""$thisWWN"""


### PR DESCRIPTION
Brocade switch will automatically set the WWN to lowercase, however the
grep command will fail if the input WWNs use upper case characters,
because the brocade nsshow displays WWNs in lowercase
